### PR TITLE
Converts battery state information to double

### DIFF
--- a/Sentinel/Classes/Core/Internal/DeviceTool.swift
+++ b/Sentinel/Classes/Core/Internal/DeviceTool.swift
@@ -59,13 +59,18 @@ private extension DeviceTool {
     var batteryState: String {
         switch UIDevice.current.batteryState {
         case .charging:
-            return "Charging at: \(UIDevice.current.batteryLevel.description)%"
+            return "Charging at: \(calculateBatteryPercentage(with: UIDevice.current.batteryLevel.description))%"
         case .full:
             return "Full"
         case .unplugged:
-            return "\(UIDevice.current.batteryLevel.description)%"
+            return "\(calculateBatteryPercentage(with: UIDevice.current.batteryLevel.description))%"
         default:
             return "Unknown"
         }
+    }
+
+    func calculateBatteryPercentage(with amount: String) -> String {
+        guard let batteryLevel = Double(amount) else { return "Unknown" }
+        return "\(batteryLevel * 100.0)"
     }
 }


### PR DESCRIPTION
- Changed Battery state field on Device tab to be displayed as double value from 0 - 100%