### PR TITLE
Feature/privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,8 @@ let package = Package(
                 "Classes/Collar/CollarTool.swift"
             ],
             resources: [
-                .process("Assets")
+                .process("Assets"),
+                .copy("SupportingFiles/PrivacyInfo.xcprivacy")
             ]
         ),
         .target(

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ let configuration = Sentinel.Configuration(
 Sentinel.shared.setup(with: configuration)
 ```
 
+## Privacy
+
+Sentinel does not collect any user data. We have provided a [privacy manifest](https://github.com/infinum/ios-sentinel/blob/master/Sentinel/SupportingFiles/PrivacyInfo.xcprivacy) file that can be included in your app.
+
+
 ## Authors
 
 * Vlaho Poluta, vlaho.poluta@infinum.com

--- a/Sentinel.podspec
+++ b/Sentinel.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Sentinel'
-  s.version          = '1.2.0'
+  s.version          = '1.2.1'
   s.summary          = 'Developer\'s toolbox for debugging applications'
 
   s.description      = <<-DESC
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.ios.deployment_target = '11.0'
   s.resource_bundles = {
-      'Sentinel' => ['Sentinel/Assets/**/*'],
+      'Sentinel' => ['Sentinel/Assets/**/*', 'Sentinel/SupportingFiles/PrivacyInfo.xcprivacy'],
     }
   s.resources = 'Sentinel/Assets/**/*.{pdf}'
   s.default_subspec = 'Default'

--- a/Sentinel/SupportingFiles/PrivacyInfo.xcprivacy
+++ b/Sentinel/SupportingFiles/PrivacyInfo.xcprivacy
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sentinel/SupportingFiles/PrivacyInfo.xcprivacy
+++ b/Sentinel/SupportingFiles/PrivacyInfo.xcprivacy
@@ -8,6 +8,14 @@
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>


### PR DESCRIPTION
### This PR adds privacy manifest to the library

- Library version is raised to 1.2.1
- Added 2 input to manifest, one for UserDefaults and one for systemUptime
- Cocoapods integration works
- Generated privacy report finds no issues
- Readme.md is updated