### PR TITLE
Fix/newfound issues

### DIFF
--- a/Sentinel/Classes/Core/Internal/SentinelTabBarView.swift
+++ b/Sentinel/Classes/Core/Internal/SentinelTabBarView.swift
@@ -31,11 +31,13 @@ public struct SentinelTabBarView: View {
                 #if os(macOS)
                 SentinelListView(title: tab.barItemTitle, items: tab.sections)
                     .tabItem { TabBarView(tab: tab) }
+                    .tag(tab.tabViewTab)
                 #else
                 NavigationView {
                     SentinelListView(title: tab.barItemTitle, items: tab.sections)
                 }
                 .tabItem { TabBarView(tab: tab) }
+                .tag(tab.tabViewTab)
                 #endif
             }
         }

--- a/Sentinel/Classes/Core/Internal/SentinelTabItem.swift
+++ b/Sentinel/Classes/Core/Internal/SentinelTabItem.swift
@@ -45,6 +45,16 @@ extension SentinelTabItem {
         }
     }
 
+    var tabViewTab: Tab {
+        switch tab {
+        case .device: .device
+        case .application: .application
+        case .tools: .tools
+        case .preferences: .preferences
+        case .performance: .performance
+        }
+    }
+
     var sections: [ToolTableSection] {
         toolTable.sections
     }

--- a/Sentinel/Classes/UserDefaults/UserDefaultsToolDetailViewModel.swift
+++ b/Sentinel/Classes/UserDefaults/UserDefaultsToolDetailViewModel.swift
@@ -32,7 +32,7 @@ final class UserDefaultsToolDetailViewModel: ObservableObject {
 extension UserDefaultsToolDetailViewModel {
 
     func didPressDelete() {
-        UserDefaults.standard.removeObject(forKey: title)
+        userDefaults.removeObject(forKey: title)
         didDeleteProperty?()
     }
 


### PR DESCRIPTION
## Summary

It provides two fixes, one reported on MacOS, one I found during testing

**Related issue**: 
- issue where on MacOS 15+ the TabView wasn't responding
- issue where we used UserDefaults.standard in the UserDefaults details view instead of the passed UserDefaults

## Changes

Use the injected UserDefaults instead of the standard one in the UserDefaults tool
Add Tags to the SentinelTabView so that it's responsive on MacOS 15+, and that we can preselect a tab

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [X] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

Use the injected UserDefaults instead of the standard one in the UserDefaults tool
Add Tags to the SentinelTabView so that it's responsive on MacOS 15+, and that we can preselect a tab

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have tested my changes, including edge cases.
- [X] I have added necessary tests for the changes introduced (if applicable).
- [X] I have updated the documentation to reflect my changes (if applicable).

## Additional notes
