### PR TITLE
Add dismiss on trigger if Sentinel is already shown

### DIFF
--- a/Sentinel/Classes/Core/Sentinel.swift
+++ b/Sentinel/Classes/Core/Sentinel.swift
@@ -30,8 +30,8 @@ public final class Sentinel {
     public func setup(with configuration: Configuration) {
         self.configuration = configuration
         configuration.trigger?.subscribe {
-            guard !configuration.sourceScreenProvider.isSentinelShown() else {
-                configuration.sourceScreenProvider.dismissSentinel()
+            guard !configuration.sourceScreenProvider.isShown() else {
+                configuration.sourceScreenProvider.dismiss()
                 return
             }
             configuration.sourceScreenProvider.showTools(for: Self.createSentinelView(with: configuration))

--- a/Sentinel/Classes/Core/Sentinel.swift
+++ b/Sentinel/Classes/Core/Sentinel.swift
@@ -30,6 +30,10 @@ public final class Sentinel {
     public func setup(with configuration: Configuration) {
         self.configuration = configuration
         configuration.trigger?.subscribe {
+            guard configuration.sourceScreenProvider.shouldShowSentinel() else {
+                configuration.sourceScreenProvider.dismissSentinel()
+                return
+            }
             configuration.sourceScreenProvider.showTools(for: Self.createSentinelView(with: configuration))
         }
     }

--- a/Sentinel/Classes/Core/Sentinel.swift
+++ b/Sentinel/Classes/Core/Sentinel.swift
@@ -30,7 +30,7 @@ public final class Sentinel {
     public func setup(with configuration: Configuration) {
         self.configuration = configuration
         configuration.trigger?.subscribe {
-            guard configuration.sourceScreenProvider.shouldShowSentinel() else {
+            guard !configuration.sourceScreenProvider.isSentinelShown() else {
                 configuration.sourceScreenProvider.dismissSentinel()
                 return
             }

--- a/Sentinel/Classes/Core/SourceScreenProvider.swift
+++ b/Sentinel/Classes/Core/SourceScreenProvider.swift
@@ -15,7 +15,7 @@ public protocol SourceScreenProvider {
     func showTools(for view: some View)
 
     /// Checks if Sentinel is already shown
-    func shouldShowSentinel() -> Bool
+    func isSentinelShown() -> Bool
 
     /// Dismisses Sentinel, used if the user triggers the showing of Sentinel but it is already shown
     func dismissSentinel()
@@ -43,8 +43,8 @@ public struct DefaultSourceScreenProvider: SourceScreenProvider {
         keyWindow?.contentViewController?.presentAsModalWindow(controller)
     }
 
-    public func shouldShowSentinel() -> Bool {
-        !NSApplication.shared.windows.compactMap(\.contentViewController).contains(where: { $0 is NSHostingController<SentinelTabBarView> })
+    public func isSentinelShown() -> Bool {
+        NSApplication.shared.windows.compactMap(\.contentViewController).contains(where: { $0 is NSHostingController<SentinelTabBarView> })
     }
 
     public func dismissSentinel() {
@@ -56,8 +56,8 @@ public struct DefaultSourceScreenProvider: SourceScreenProvider {
         topMostController()?.present(UIHostingController(rootView: view), animated: true)
     }
 
-    public func shouldShowSentinel() -> Bool {
-        !(topMostController() is UIHostingController<SentinelTabBarView>)
+    public func isSentinelShown() -> Bool {
+        topMostController() is UIHostingController<SentinelTabBarView>
     }
 
     public func dismissSentinel() {

--- a/Sentinel/Classes/Core/SourceScreenProvider.swift
+++ b/Sentinel/Classes/Core/SourceScreenProvider.swift
@@ -15,10 +15,10 @@ public protocol SourceScreenProvider {
     func showTools(for view: some View)
 
     /// Checks if Sentinel is already shown
-    func isSentinelShown() -> Bool
+    func isShown() -> Bool
 
     /// Dismisses Sentinel, used if the user triggers the showing of Sentinel but it is already shown
-    func dismissSentinel()
+    func dismiss()
 }
 
 /// Provides possible source screens used for presenting the Sentinel.
@@ -43,11 +43,11 @@ public struct DefaultSourceScreenProvider: SourceScreenProvider {
         keyWindow?.contentViewController?.presentAsModalWindow(controller)
     }
 
-    public func isSentinelShown() -> Bool {
+    public func isShown() -> Bool {
         NSApplication.shared.windows.compactMap(\.contentViewController).contains(where: { $0 is NSHostingController<SentinelTabBarView> })
     }
 
-    public func dismissSentinel() {
+    public func dismiss() {
         NSApplication.shared.windows.first(where: { $0.contentViewController is NSHostingController<SentinelTabBarView> })?.close()
     }
     #else
@@ -56,11 +56,11 @@ public struct DefaultSourceScreenProvider: SourceScreenProvider {
         topMostController()?.present(UIHostingController(rootView: view), animated: true)
     }
 
-    public func isSentinelShown() -> Bool {
+    public func isShown() -> Bool {
         topMostController() is UIHostingController<SentinelTabBarView>
     }
 
-    public func dismissSentinel() {
+    public func dismiss() {
         topMostController()?.dismiss(animated: true)
     }
 

--- a/Sentinel/Classes/Core/SourceScreenProvider.swift
+++ b/Sentinel/Classes/Core/SourceScreenProvider.swift
@@ -13,6 +13,12 @@ public protocol SourceScreenProvider {
 
     /// The view controller used for presenting the Sentinel.
     func showTools(for view: some View)
+
+    /// Checks if Sentinel is already shown
+    func shouldShowSentinel() -> Bool
+
+    /// Dismisses Sentinel, used if the user triggers the showing of Sentinel but it is already shown
+    func dismissSentinel()
 }
 
 /// Provides possible source screens used for presenting the Sentinel.
@@ -36,10 +42,26 @@ public struct DefaultSourceScreenProvider: SourceScreenProvider {
         controller.view.frame = NSRect(x: 0, y: 0, width: 1200, height: 800)
         keyWindow?.contentViewController?.presentAsModalWindow(controller)
     }
+
+    public func shouldShowSentinel() -> Bool {
+        !NSApplication.shared.windows.compactMap(\.contentViewController).contains(where: { $0 is NSHostingController<SentinelTabBarView> })
+    }
+
+    public func dismissSentinel() {
+        NSApplication.shared.windows.first(where: { $0.contentViewController is NSHostingController<SentinelTabBarView> })?.close()
+    }
     #else
     
     public func showTools(for view: some View) {
         topMostController()?.present(UIHostingController(rootView: view), animated: true)
+    }
+
+    public func shouldShowSentinel() -> Bool {
+        !(topMostController() is UIHostingController<SentinelTabBarView>)
+    }
+
+    public func dismissSentinel() {
+        topMostController()?.dismiss(animated: true)
     }
 
     // MARK: - Private methods


### PR DESCRIPTION
## Summary

Added a requested feature by the QA team to dismiss Sentinel on the second shake if it has already been presented.

## Changes

### Type

- [X] **Feature**: This pull request introduces a new feature.
- [ ] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [X] This pull request introduces a **breaking change**.

### Description

Added a check in the SourceScreenProvider to see if the SentinelTabBarView is already present, if so, dismiss it. If not, show Sentinel

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have tested my changes, including edge cases.
- [X] I have added necessary tests for the changes introduced (if applicable).
- [X] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

We can fix the breaking change by implementing a default implementation for it. I would like to hear your opinion on it, I'm more for a default implementation, and this not being a breaking change
